### PR TITLE
fix: return type for JestorRuleGetter can be any

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ it('should return 4 whan called with 44', function () {
 #### Describing multiple rules
 
 If you want to define multiple rules, `followRules` should be used.  
-It accepts a function, which should return array of rules, which define what mock should do when the given condition is met:
+It accepts a function, which define what mock should do when the given condition is met:
 
 ```javascript
-it('should allow to define multiple rules', function() {
+it('should allow to define multiple rules', function () {
   const spy = jest.fn()
-  jestor(spy).followRules(rules => [
-    rules.whenCalledWith(1).return(false),
-    rules.whenCalledWith(2).return(true),
-    rules.whenCalledWith('foo').resolveWith('foo'),
+  jestor(spy).followRules((rules) => {
+    rules.whenCalledWith(1).return(false)
+    rules.whenCalledWith(2).return(true)
+    rules.whenCalledWith('foo').resolveWith('foo')
     rules.whenCalledWith('bar').rejectWith('bar')
-  ])
+  })
 
   expect(spy(1)).toBe(false)
   expect(spy(2)).toBe(true)
@@ -77,7 +77,7 @@ it('should allow to define multiple rules', function() {
   const foo = await spy('foo')
   expect(foo).toBe('foo')
 
-  await spy('bar').catch(e => {
+  await spy('bar').catch((e) => {
     expect(e).toBe('bar')
   })
 })
@@ -154,7 +154,7 @@ Describes that the the promise resolved with `val` should be returned when mock 
 ```javascript
 import { jestor } from 'jestor'
 
-it('should return resolved promise when resolveWith is used', function() {
+it('should return resolved promise when resolveWith is used', function () {
   const mock = jest.fn()
 
   // tell jestor to return promise resolved with 6 when mock is called with 3
@@ -182,15 +182,15 @@ Describes that the the promise rejected with `val` should be returned when mock 
 ```javascript
 import { jestor } from 'jestor'
 
-it('should return rejected promise when rejectWith is used', function() {
+it('should return rejected promise when rejectWith is used', function () {
   const mock = jest.fn()
 
   // tell jestor to return rejected promise
-  jestor(mock).whenCalledWith(2).rejectWith('failure');
+  jestor(mock).whenCalledWith(2).rejectWith('failure')
 
   // assert if we really got a promise rejected with 'failure'
-  const err = await mock(2).catch(e => e);
-  expect(err).toBe('failure');
+  const err = await mock(2).catch((e) => e)
+  expect(err).toBe('failure')
 })
 ```
 
@@ -248,11 +248,11 @@ import { jestor } from 'jestor'
 describe('my function', function () {
   it('should return a value', function () {
     const mock = jest.fn()
-    jestor(mock).followRules((rules) => [
-      rules.whenCalledWith('Alice').return('human'),
-      rules.whenCalledWith(expect.any(Number), expect.any(Number)).return('numbers'),
-      rules.whenCalledWith(expect.any(Function)).return('function'),
-    ])
+    jestor(mock).followRules((rules) => {
+      rules.whenCalledWith('Alice').return('human')
+      rules.whenCalledWith(expect.any(Number), expect.any(Number)).return('numbers')
+      rules.whenCalledWith(expect.any(Function)).return('function')
+    })
   })
 })
 ```

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -3,12 +3,12 @@ import { jestor } from './index'
 describe('jestor', function () {
   it(`should allow to specify multiple rules using followRules`, async function () {
     const spy = jest.fn()
-    jestor(spy).followRules((rules) => [
-      rules.whenCalledWith(1).return(false),
-      rules.whenCalledWith(2).return(true),
-      rules.whenCalledWith('foo').resolveWith('foo'),
-      rules.whenCalledWith('bar').rejectWith('bar'),
-    ])
+    jestor(spy).followRules((rules) => {
+      rules.whenCalledWith(1).return(false)
+      rules.whenCalledWith(2).return(true)
+      rules.whenCalledWith('foo').resolveWith('foo')
+      rules.whenCalledWith('bar').rejectWith('bar')
+    })
 
     expect(spy(1)).toBe(false)
     expect(spy(2)).toBe(true)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,9 @@ interface IJestorBehavior {
   throw(value: any): void
 }
 
-type JestorRuleGetter = (ruleBuilder: { whenCalledWith(...args: any[]): IJestorBehavior }) => any[]
+type JestorRuleGetter = (ruleBuilder: {
+  whenCalledWith(...args: any[]): IJestorBehavior
+}) => unknown
 
 interface IJestor {
   whenCalledWith(...args: any[]): IJestorBehavior
@@ -17,7 +19,7 @@ export function jestor(jestMock: jest.Mock): IJestor {
   return {
     followRules: (ruleGetter) => {
       ruleGetter({
-        whenCalledWith: getRuleBuilder((rule) => rules.push(rule)),
+        whenCalledWith: getRuleBuilder((rule) => rules.push(rule))
       })
       return jestMock.mockImplementation((...actualArgs) => {
         for (let i = rules.length - 1; i >= 0; --i) {
@@ -37,7 +39,7 @@ export function jestor(jestMock: jest.Mock): IJestor {
           return rule.valueWrapper(rule.returnValue)
         }
       })
-    }),
+    })
   }
 }
 
@@ -50,9 +52,9 @@ const equals = (function () {
         jestEqual = this.equals
         return {
           pass: true,
-          message: () => '',
+          message: () => ''
         }
-      },
+      }
     })
     expect(1)[MATCHER_NAME]()
     delete expect[MATCHER_NAME]
@@ -80,7 +82,7 @@ function getRuleBuilder(collectRule) {
     const rule = {
       matcher: getRuleMatcher(expectedArgs),
       valueWrapper: undefined,
-      returnValue: undefined,
+      returnValue: undefined
     }
     return {
       return: (returnValue) => {
@@ -107,7 +109,7 @@ function getRuleBuilder(collectRule) {
         }
         rule.returnValue = value
         collectRule(rule)
-      },
+      }
     }
   }
 }


### PR DESCRIPTION
The JestorRuleGetter doesn't use its returned value.
The recommended function return type signature is void.

unkown is declared to avoid breaking change